### PR TITLE
make the .sky-label selector configurable

### DIFF
--- a/lib/sky-labels-rails.rb
+++ b/lib/sky-labels-rails.rb
@@ -1,4 +1,5 @@
 require 'sky-labels-rails/version'
+require 'sky-labels-rails/config'
 
 module SkyLabels
   module Rails

--- a/lib/sky-labels-rails/config.rb
+++ b/lib/sky-labels-rails/config.rb
@@ -1,0 +1,6 @@
+module SkyLabels
+  extend self
+
+  attr_accessor :selector
+  @selector = '.sky-label'
+end

--- a/vendor/assets/javascripts/sky-labels.js.erb
+++ b/vendor/assets/javascripts/sky-labels.js.erb
@@ -10,7 +10,7 @@ var setupSkyLabels = function () {
   $(document).on("focus blur", "<%= SkyLabels.selector %>", addOrRemoveHasTextClass);
   $(document).on("focus", "<%= SkyLabels.selector %>", addFocusedClass);
   $(document).on("blur", "<%= SkyLabels.selector %>", removeFocusedClass);
-  $(document).on("ready, page:change", "<%= SkyLabels.selector %>", hideLabelsIfInputHasText);
+  $(document).ready(hideLabelsIfInputHasText);
 
   function addFocusedClass(event) {
     var fieldWrapper = $(event.currentTarget);

--- a/vendor/assets/javascripts/sky-labels.js.erb
+++ b/vendor/assets/javascripts/sky-labels.js.erb
@@ -7,10 +7,10 @@
  *  Under MIT License
  */
 var setupSkyLabels = function () {
-  $(document).on("focus blur", ".sky-label", addOrRemoveHasTextClass);
-  $(document).on("focus", ".sky-label", addFocusedClass);
-  $(document).on("blur", ".sky-label", removeFocusedClass);
-  $(document).ready(hideLabelsIfInputHasText);
+  $(document).on("focus blur", "<%= SkyLabels.selector %>", addOrRemoveHasTextClass);
+  $(document).on("focus", "<%= SkyLabels.selector %>", addFocusedClass);
+  $(document).on("blur", "<%= SkyLabels.selector %>", removeFocusedClass);
+  $(document).on("ready, page:change", "<%= SkyLabels.selector %>", hideLabelsIfInputHasText);
 
   function addFocusedClass(event) {
     var fieldWrapper = $(event.currentTarget);
@@ -23,7 +23,7 @@ var setupSkyLabels = function () {
   }
 
   function hideLabelsIfInputHasText() {
-    $(".sky-label").trigger("blur");
+    $("<%= SkyLabels.selector %>").trigger("blur");
   }
 
   function addOrRemoveHasTextClass(event) {

--- a/vendor/assets/stylesheets/sky-labels.scss.erb
+++ b/vendor/assets/stylesheets/sky-labels.scss.erb
@@ -3,12 +3,12 @@ $sky-labels-focused-background-color: #000 !default;
 $sky-labels-focused-text-color: #FFF !default;
 $sky-labels-animation-duration: .15s !default;
 
-.sky-label {
+<%= SkyLabels.selector %> {
   margin-top: 15px;
   position: relative;
 }
 
-.sky-label label {
+<%= SkyLabels.selector %> label {
   color: $sky-labels-blurred-text-color;
   left: 4px;
   padding: 4px 6px;


### PR DESCRIPTION
Allow easier integration with existing code. For example, if Bootstrap is used, then you just have to define `SkyLabels.selector = '.form-group'` in a initializer.
